### PR TITLE
Update README.md to use v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To include, add the following to your build.gradle
         repositories { jcenter() }
 
         dependencies {
-            classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:1.12.+'
+            classpath 'com.netflix.nebula:gradle-extra-configurations-plugin:2.2.0'
         }
     }
 


### PR DESCRIPTION
On the gradle-2.2 branch, the README still uses version `1.12.+`. I think it should match the actual version in the branch, to make usage clearer.